### PR TITLE
Update chainbridge version for evm instructions

### DIFF
--- a/docs/live-evm-bridge.md
+++ b/docs/live-evm-bridge.md
@@ -196,7 +196,7 @@ In configuring the destination bridge contract we set the relayer threshold to 1
 #### 1. Build the relayer
 
 ```shell
-git clone -b v1.0.0 --depth 1 https://github.com/ChainSafe/chainbridge \
+git clone -b v1.1.1 --depth 1 https://github.com/ChainSafe/chainbridge \
 && cd chainbridge \
 && make build
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updates chainbridge version to ensure compatibility when running against Geth 1.10 or later.
